### PR TITLE
Disable chrome styled input elements

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,8 +10,7 @@
   },
   "options_ui": {
     "page": "options.html",
-    "open_in_tab": false,
-    "chrome_style": true
+    "open_in_tab": false
   },
   "permissions": ["storage"],
   "content_scripts": [


### PR DESCRIPTION
This reverts the UI changes from #301 ([explanation](https://github.com/prettier/prettier-chrome-extension/pull/301#issuecomment-679779109)) without reverting the disabling of `spellCheck`.