### PR TITLE
Fix loading Chrome extension from production build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const TerserPlugin = require("terser-webpack-plugin"); // included as a dependency of webpack
 const CopyPlugin = require("copy-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const HTMLPlugin = require("html-webpack-plugin");
@@ -44,6 +45,18 @@ module.exports = ({ outDir, env }) => {
             "sass-loader",
           ],
         },
+      ],
+    },
+    optimization: {
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            extractComments: false,
+
+            // https://github.com/webpack-contrib/terser-webpack-plugin/issues/107
+            output: { ascii_only: true },
+          },
+        }),
       ],
     },
     output: {


### PR DESCRIPTION
#328 has fixed the development build in Chrome (tracked in #203), but it seems like it also broke the production build (as we still need the custom terser options for Prettier 2).

@sibiraj-s @kaicataldo Sorry I didn't notice this until after merging #328, but it's still helpful for fixing the development build.