### PR TITLE
Switch to Prettier's ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "classnames": "2.2.6",
-    "prettier": "2.2.0",
+    "prettier": "2.2.1",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "classnames": "2.2.6",
-    "prettier": "2.1.1",
+    "prettier": "2.2.0",
     "prop-types": "15.7.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/src/content/github.js
+++ b/src/content/github.js
@@ -5,7 +5,7 @@ import renderButton, {
   COMMENT_SIBLING_SELECTORS_TO_DEFER_TO,
 } from "./button";
 import { PARSERS } from "./parsers";
-import prettier from "prettier/standalone";
+import prettier from "prettier/esm/standalone";
 
 const GITHUB_URL = "https://github.com";
 const GITHUB_VALID_PATHNAMES = /^\/.*\/.*\/(?:pull\/\d+(?:\/?|\/files\/?)$|commits?\/.*|compare\/.*|issues\/\d+|issues|wiki|wiki\/\d+\/(_?new|_edit))/u;

--- a/src/content/leetCode.js
+++ b/src/content/leetCode.js
@@ -1,5 +1,5 @@
 import { PARSERS, PARSERS_LANG_MAP } from "./parsers";
-import prettier from "prettier/standalone";
+import prettier from "prettier/esm/standalone";
 import renderButton from "./button";
 
 const LEETCODE_URL = "https://leetcode.com";

--- a/src/content/parsers.js
+++ b/src/content/parsers.js
@@ -1,13 +1,13 @@
-import parserAngular from "prettier/parser-angular";
-import parserBabel from "prettier/parser-babel";
-import parserFlow from "prettier/parser-flow";
-import parserGlimmer from "prettier/parser-glimmer";
-import parserGraphql from "prettier/parser-graphql";
-import parserHtml from "prettier/parser-html";
-import parserMarkdown from "prettier/parser-markdown";
-import parserPostcss from "prettier/parser-postcss";
-import parserTypescript from "prettier/parser-typescript";
-import parserYaml from "prettier/parser-yaml";
+import parserAngular from "prettier/esm/parser-angular";
+import parserBabel from "prettier/esm/parser-babel";
+import parserFlow from "prettier/esm/parser-flow";
+import parserGlimmer from "prettier/esm/parser-glimmer";
+import parserGraphql from "prettier/esm/parser-graphql";
+import parserHtml from "prettier/esm/parser-html";
+import parserMarkdown from "prettier/esm/parser-markdown";
+import parserPostcss from "prettier/esm/parser-postcss";
+import parserTypescript from "prettier/esm/parser-typescript";
+import parserYaml from "prettier/esm/parser-yaml";
 
 export const PARSERS = [
   parserAngular,

--- a/src/content/stackOverflow.js
+++ b/src/content/stackOverflow.js
@@ -1,5 +1,5 @@
 import { PARSERS, PARSERS_LANG_MAP } from "./parsers";
-import prettier from "prettier/standalone";
+import prettier from "prettier/esm/standalone";
 import renderButton from "./button";
 
 const STACKEXCHANGE_SITES = [

--- a/src/options/JsonConfig.js
+++ b/src/options/JsonConfig.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import parserBabel from "prettier/parser-babel";
-import prettier from "prettier/standalone";
+import parserBabel from "prettier/esm/parser-babel";
+import prettier from "prettier/esm/standalone";
 import { validateOptions } from "./options";
 
 const SAVED_TIMEOUT = 2000;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,6 +95,9 @@ module.exports = ({ outDir, env }) => {
       !isDevMode && new CleanWebpackPlugin(),
       new webpack.ProgressPlugin(),
     ].filter(Boolean),
+    resolve: {
+      extensions: [".mjs", ".js"],
+    },
     watch: isDevMode,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7813,10 +7813,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
-  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
+prettier@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
+  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
 
 pretty-error@^2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7813,10 +7813,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
-  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
+prettier@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-error@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
https://prettier.io/blog/2020/11/20/2.2.0.html#esm-standalone-bundles-8983httpsgithubcomprettierprettierpull8983-by-monchihttpsgithubcommonchi-fiskerhttpsgithubcomfisker

Now we're importing from Prettier's new ESM standalone build instead of its CJS standalone build