### PR TITLE
Rename master -> main in CI GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   ci:
     name: CI

--- a/src/content/extension.js
+++ b/src/content/extension.js
@@ -33,7 +33,7 @@ export default class Extension {
 
       const inputEl = document.activeElement;
 
-      if (!inputEl?.tagName === 'TEXTAREA') {
+      if (!inputEl?.tagName === "TEXTAREA") {
         return;
       }
 


### PR DESCRIPTION
This is the one change required now that we've moved to `main` as the main branch.